### PR TITLE
Decouple the help center after the latest release

### DIFF
--- a/decouple-the-help-center-after-the-latest-release.md
+++ b/decouple-the-help-center-after-the-latest-release.md
@@ -1,0 +1,1 @@
+Content for file decouple-the-help-center-after-the-latest-release.md


### PR DESCRIPTION
This was requested by several customers during recent calls.

The design mockups for this are available in the shared drive.

This was flagged during the last round of QA testing.

Fixes #274