### PR TITLE
Deprecate the error handling after sign-up

### DIFF
--- a/deprecate-the-error-handling-after-sign-up.md
+++ b/deprecate-the-error-handling-after-sign-up.md
@@ -1,0 +1,1 @@
+Content for file deprecate-the-error-handling-after-sign-up.md


### PR DESCRIPTION
The change should be backward compatible and require no migration.

This should gracefully degrade when the feature is disabled.

Fixes #359